### PR TITLE
[RPLUS-75690] PlatformView null handling

### DIFF
--- a/VirtualListView/Apple/VirtualListViewHandler.ios.maccatalyst.cs
+++ b/VirtualListView/Apple/VirtualListViewHandler.ios.maccatalyst.cs
@@ -229,7 +229,7 @@ public partial class VirtualListViewHandler : ViewHandler<IVirtualListView, UIVi
 
 	public void InvalidateData()
 	{
-		if (this.SuspendInvalidateUpdate())
+		if (this.SuspendInvalidateUpdate() || this.Controller is null)
 		{
 			return;
 		}

--- a/VirtualListView/VirtualListView.csproj
+++ b/VirtualListView/VirtualListView.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
 		
 		<UseMaui>true</UseMaui>


### PR DESCRIPTION
* When invalidating data, actions on `PlatformView` when it is null cause an `InvalidOperationException`
* null checks against `PlatformView` also throw the `InvalidOperationException` because it calls the getter
* `Controller` also happens to be null when the `PlatformView` is null
* This checks the value of `Controller` for null, if it is null, it early returns and no operation on `PlatformView` is performed
* Upgrades to .NET 9