### PR TITLE
[RPLUS-75454] Prevent Duplicate Key Exception

### DIFF
--- a/VirtualListView/Apple/CvLayout.ios.maccatalyst.cs
+++ b/VirtualListView/Apple/CvLayout.ios.maccatalyst.cs
@@ -88,7 +88,7 @@ internal sealed class CvLayout : UICollectionViewLayout
         {
             int hashCode = this.previousItemPositionCache[i];
             CGSize size = this.cache[i].Size;
-            previousItemLookUp.Add(hashCode, size);
+            previousItemLookUp.TryAdd(hashCode, size);
         }
 
         IReadOnlyList<int> newItemHashes = DataSource.ItemPositionCache;


### PR DESCRIPTION
* Changing the adding of the size to the dictionary to use a TryAdd instead of an Add in case of any hash code collisions.
* This work coincides with the value based hash work that was done in the mobile app that consumes it