### PR TITLE
[RPLUS-76241] Remove potential ArgumentOutOfRangeException

### DIFF
--- a/VirtualListView/Platforms/Android/RvAdapter.cs
+++ b/VirtualListView/Platforms/Android/RvAdapter.cs
@@ -121,7 +121,7 @@ public partial class RvAdapter : RecyclerView.Adapter
         var info = positionInfoCache.ElementAtOrDefault(position);
         if (info == null)
         {
-            // return no reuse id becauet the item view could not be found in the cache.
+            // return no reuse id because the item view could not be found in the cache.
             return -1;
         }
 

--- a/VirtualListView/Platforms/Android/RvAdapter.cs
+++ b/VirtualListView/Platforms/Android/RvAdapter.cs
@@ -118,7 +118,12 @@ public partial class RvAdapter : RecyclerView.Adapter
 
     public override int GetItemViewType(int position)
     {
-        var info = positionInfoCache[position];
+        var info = positionInfoCache.ElementAtOrDefault(position);
+        if (info == null)
+        {
+            // return no reuse id becauet the item view could not be found in the cache.
+            return -1;
+        }
 
         var data = info.Kind switch
         {
@@ -147,7 +152,7 @@ public partial class RvAdapter : RecyclerView.Adapter
                     PositionKind.Header => 1,
                     PositionKind.Item => itemMaxRecyclerViews,
                     PositionKind.Footer => 1,
-                    _ => 5
+                    _ => 5,
                 };
                 recycledViewPool.SetMaxRecycledViews(reuseIdNumber, resusePoolCount);
             }


### PR DESCRIPTION
* We're getting a few ArgumentOutOfRangeExceptions from the GetItemViewType method on the RvAdapter.
* This is happening when getting an item from a list.
* This commit prevents the crash from happening, while causing the method to return a -1 because no reuse id can be determined.
   * -1 is what is returned later in the method if the reuse id cannot be determined, so an early return seems to be the valid result in this case.
* There is likely a need to re-evaluate how InvalidateData() is being called in the consumer so that the cache is properly re-populated